### PR TITLE
LunchHubApi のベースを実装

### DIFF
--- a/Data/Api/LunchHubApi/LunchHubApi.swift
+++ b/Data/Api/LunchHubApi/LunchHubApi.swift
@@ -1,0 +1,9 @@
+//
+//  LunchHubApi.swift
+//  Data
+//
+//  Created by Atsushi Miyake on 2019/04/30.
+//  Copyright © 2019 Tokyo Lunch Hub. All rights reserved.
+//
+
+public struct LunchHubApi {}

--- a/Data/Api/LunchHubApi/LunchHubApi.swift
+++ b/Data/Api/LunchHubApi/LunchHubApi.swift
@@ -6,4 +6,12 @@
 //  Copyright © 2019 Tokyo Lunch Hub. All rights reserved.
 //
 
-public struct LunchHubApi {}
+public struct LunchHubApi {
+    
+    public static let shared = LunchHubApi()
+    private init() {}
+    
+    public static func changeHost(to apiHost: LunchHubApiHost) {
+        lunchHubApiHost = apiHost
+    }
+}

--- a/Data/Api/LunchHubApi/LunchHubApiEndpoint.swift
+++ b/Data/Api/LunchHubApi/LunchHubApiEndpoint.swift
@@ -1,0 +1,27 @@
+//
+//  LunchHubApiEndpoint.swift
+//  Data
+//
+//  Created by Atsushi Miyake on 2019/04/30.
+//  Copyright © 2019 Tokyo Lunch Hub. All rights reserved.
+//
+
+import Moya
+
+protocol LunchHubApiEndpoint: TargetType {}
+
+extension LunchHubApiEndpoint {
+    
+    var baseURL: URL {
+        return URL(string: "")!
+    }
+    
+    var sampleData: Data {
+        return Data()
+    }
+    
+    var headers: [String : String]? {
+        return [:]
+    }
+}
+

--- a/Data/Api/LunchHubApi/LunchHubApiEndpoint.swift
+++ b/Data/Api/LunchHubApi/LunchHubApiEndpoint.swift
@@ -13,7 +13,7 @@ protocol LunchHubApiEndpoint: TargetType {}
 extension LunchHubApiEndpoint {
     
     var baseURL: URL {
-        return URL(string: "")!
+        return lunchHubApiHost.url
     }
     
     var sampleData: Data {

--- a/Data/Api/LunchHubApi/LunchHubApiHost.swift
+++ b/Data/Api/LunchHubApi/LunchHubApiHost.swift
@@ -1,0 +1,31 @@
+//
+//  LunchHubApiHost.swift
+//  Data
+//
+//  Created by Atsushi Miyake on 2019/04/30.
+//  Copyright © 2019 Tokyo Lunch Hub. All rights reserved.
+//
+
+import Foundation
+
+var lunchHubApiHost: LunchHubApiHost = .development
+
+public enum LunchHubApiHost {
+    case development
+    case staging
+    case infiniteStaging(name: String)
+    case production
+    
+    var url: URL {
+        switch self {
+        case .development:
+            return URL(string: "https://api.lunch-hub-development.com")!
+        case .staging:
+            return URL(string: "https://api.lunch-hub-staging.com")!
+        case let .infiniteStaging(name):
+            return URL(string: "https://\(name)-api.lunch-hub-staging.com")!
+        case .production:
+            return URL(string:  "https://api.lunch-hub.com")!
+        }
+    }
+}

--- a/Data/Api/LunchHubApi/LunchHubApiService.swift
+++ b/Data/Api/LunchHubApi/LunchHubApiService.swift
@@ -1,0 +1,14 @@
+//
+//  LunchHubApiService.swift
+//  Data
+//
+//  Created by Atsushi Miyake on 2019/04/30.
+//  Copyright © 2019 Tokyo Lunch Hub. All rights reserved.
+//
+
+import Moya
+
+protocol LunchHubApiService {
+    associatedtype Endpoint: LunchHubApiEndpoint
+    var provider: MoyaProvider<Endpoint> { get }
+}

--- a/lunch-hub.xcodeproj/project.pbxproj
+++ b/lunch-hub.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		0DB63E6B2278792E00D89682 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0DB63E632278792E00D89682 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7322787A2F00D89682 /* LunchHubApi.swift */; };
 		0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */; };
+		0DB63E7822787AE600D89682 /* LunchHubApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7722787AE600D89682 /* LunchHubApiService.swift */; };
 		3354207322781E4100D64F5A /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206322781E4000D64F5A /* RxAtomic.framework */; };
 		3354207422781E4100D64F5A /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206422781E4000D64F5A /* ReactiveSwift.framework */; };
 		3354207522781E4100D64F5A /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206522781E4000D64F5A /* RxSwiftExt.framework */; };
@@ -144,6 +145,7 @@
 		0DB63E662278792E00D89682 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0DB63E7322787A2F00D89682 /* LunchHubApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApi.swift; sourceTree = "<group>"; };
 		0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiEndpoint.swift; sourceTree = "<group>"; };
+		0DB63E7722787AE600D89682 /* LunchHubApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiService.swift; sourceTree = "<group>"; };
 		3354206222781E4000D64F5A /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = Carthage/Build/iOS/RxBlocking.framework; sourceTree = "<group>"; };
 		3354206322781E4000D64F5A /* RxAtomic.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxAtomic.framework; path = Carthage/Build/iOS/RxAtomic.framework; sourceTree = "<group>"; };
 		3354206422781E4000D64F5A /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 			children = (
 				0DB63E7322787A2F00D89682 /* LunchHubApi.swift */,
 				0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */,
+				0DB63E7722787AE600D89682 /* LunchHubApiService.swift */,
 			);
 			path = LunchHubApi;
 			sourceTree = "<group>";
@@ -789,6 +792,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DB63E7822787AE600D89682 /* LunchHubApiService.swift in Sources */,
 				0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */,
 				0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */,
 			);

--- a/lunch-hub.xcodeproj/project.pbxproj
+++ b/lunch-hub.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		0DB63E6A2278792E00D89682 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DB63E632278792E00D89682 /* Shared.framework */; };
 		0DB63E6B2278792E00D89682 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0DB63E632278792E00D89682 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7322787A2F00D89682 /* LunchHubApi.swift */; };
+		0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */; };
 		3354207322781E4100D64F5A /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206322781E4000D64F5A /* RxAtomic.framework */; };
 		3354207422781E4100D64F5A /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206422781E4000D64F5A /* ReactiveSwift.framework */; };
 		3354207522781E4100D64F5A /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206522781E4000D64F5A /* RxSwiftExt.framework */; };
@@ -142,6 +143,7 @@
 		0DB63E652278792E00D89682 /* Shared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Shared.h; sourceTree = "<group>"; };
 		0DB63E662278792E00D89682 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0DB63E7322787A2F00D89682 /* LunchHubApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApi.swift; sourceTree = "<group>"; };
+		0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiEndpoint.swift; sourceTree = "<group>"; };
 		3354206222781E4000D64F5A /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = Carthage/Build/iOS/RxBlocking.framework; sourceTree = "<group>"; };
 		3354206322781E4000D64F5A /* RxAtomic.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxAtomic.framework; path = Carthage/Build/iOS/RxAtomic.framework; sourceTree = "<group>"; };
 		3354206422781E4000D64F5A /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				0DB63E7322787A2F00D89682 /* LunchHubApi.swift */,
+				0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */,
 			);
 			path = LunchHubApi;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */,
 				0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/lunch-hub.xcodeproj/project.pbxproj
+++ b/lunch-hub.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0DB63E672278792E00D89682 /* Shared.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DB63E652278792E00D89682 /* Shared.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0DB63E6A2278792E00D89682 /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DB63E632278792E00D89682 /* Shared.framework */; };
 		0DB63E6B2278792E00D89682 /* Shared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0DB63E632278792E00D89682 /* Shared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7322787A2F00D89682 /* LunchHubApi.swift */; };
 		3354207322781E4100D64F5A /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206322781E4000D64F5A /* RxAtomic.framework */; };
 		3354207422781E4100D64F5A /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206422781E4000D64F5A /* ReactiveSwift.framework */; };
 		3354207522781E4100D64F5A /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206522781E4000D64F5A /* RxSwiftExt.framework */; };
@@ -140,6 +141,7 @@
 		0DB63E632278792E00D89682 /* Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DB63E652278792E00D89682 /* Shared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Shared.h; sourceTree = "<group>"; };
 		0DB63E662278792E00D89682 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0DB63E7322787A2F00D89682 /* LunchHubApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApi.swift; sourceTree = "<group>"; };
 		3354206222781E4000D64F5A /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = Carthage/Build/iOS/RxBlocking.framework; sourceTree = "<group>"; };
 		3354206322781E4000D64F5A /* RxAtomic.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxAtomic.framework; path = Carthage/Build/iOS/RxAtomic.framework; sourceTree = "<group>"; };
 		3354206422781E4000D64F5A /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 		0DB63E362278767200D89682 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				0DB63E7122787A1600D89682 /* Api */,
 				0DB63E372278767200D89682 /* Data.h */,
 				0DB63E382278767200D89682 /* Info.plist */,
 			);
@@ -303,6 +306,22 @@
 				0DB63E662278792E00D89682 /* Info.plist */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		0DB63E7122787A1600D89682 /* Api */ = {
+			isa = PBXGroup;
+			children = (
+				0DB63E7222787A1C00D89682 /* LunchHubApi */,
+			);
+			path = Api;
+			sourceTree = "<group>";
+		};
+		0DB63E7222787A1C00D89682 /* LunchHubApi */ = {
+			isa = PBXGroup;
+			children = (
+				0DB63E7322787A2F00D89682 /* LunchHubApi.swift */,
+			);
+			path = LunchHubApi;
 			sourceTree = "<group>";
 		};
 		3354206122781E4000D64F5A /* Frameworks */ = {
@@ -605,6 +624,7 @@
 					};
 					0DB63E342278767200D89682 = {
 						CreatedOnToolsVersion = 10.2.1;
+						LastSwiftMigration = 1020;
 					};
 					0DB63E4E2278782600D89682 = {
 						CreatedOnToolsVersion = 10.2.1;
@@ -766,6 +786,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -979,6 +1000,7 @@
 		0DB63E3E2278767200D89682 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1000,6 +1022,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.co.tokyo-lunch-hub.data";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1010,6 +1033,7 @@
 		0DB63E3F2278767200D89682 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1265,6 +1289,7 @@
 		33A4CF58227077310046A07D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1286,6 +1311,7 @@
 		33A4CF59227077310046A07D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/lunch-hub.xcodeproj/project.pbxproj
+++ b/lunch-hub.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7322787A2F00D89682 /* LunchHubApi.swift */; };
 		0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */; };
 		0DB63E7822787AE600D89682 /* LunchHubApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7722787AE600D89682 /* LunchHubApiService.swift */; };
+		0DB63E7A22787B3F00D89682 /* LunchHubApiHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB63E7922787B3F00D89682 /* LunchHubApiHost.swift */; };
 		3354207322781E4100D64F5A /* RxAtomic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206322781E4000D64F5A /* RxAtomic.framework */; };
 		3354207422781E4100D64F5A /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206422781E4000D64F5A /* ReactiveSwift.framework */; };
 		3354207522781E4100D64F5A /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3354206522781E4000D64F5A /* RxSwiftExt.framework */; };
@@ -146,6 +147,7 @@
 		0DB63E7322787A2F00D89682 /* LunchHubApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApi.swift; sourceTree = "<group>"; };
 		0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiEndpoint.swift; sourceTree = "<group>"; };
 		0DB63E7722787AE600D89682 /* LunchHubApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiService.swift; sourceTree = "<group>"; };
+		0DB63E7922787B3F00D89682 /* LunchHubApiHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchHubApiHost.swift; sourceTree = "<group>"; };
 		3354206222781E4000D64F5A /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = Carthage/Build/iOS/RxBlocking.framework; sourceTree = "<group>"; };
 		3354206322781E4000D64F5A /* RxAtomic.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxAtomic.framework; path = Carthage/Build/iOS/RxAtomic.framework; sourceTree = "<group>"; };
 		3354206422781E4000D64F5A /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 				0DB63E7322787A2F00D89682 /* LunchHubApi.swift */,
 				0DB63E7522787A8700D89682 /* LunchHubApiEndpoint.swift */,
 				0DB63E7722787AE600D89682 /* LunchHubApiService.swift */,
+				0DB63E7922787B3F00D89682 /* LunchHubApiHost.swift */,
 			);
 			path = LunchHubApi;
 			sourceTree = "<group>";
@@ -795,6 +798,7 @@
 				0DB63E7822787AE600D89682 /* LunchHubApiService.swift in Sources */,
 				0DB63E7622787A8700D89682 /* LunchHubApiEndpoint.swift in Sources */,
 				0DB63E7422787A2F00D89682 /* LunchHubApi.swift in Sources */,
+				0DB63E7A22787B3F00D89682 /* LunchHubApiHost.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Usage
Ex:
```swift
extension LunchHubApi {
  public final class MealService: LunchHubApiService {
      fileprivate init() {}
      let provider = MoyaProvider<Endpoint>()

    enum Endpoint: LunchHubApiEndpoint {
      case fetchMeals(shopId: String)
    }
  }
  public static let mealService = MealService()
}

extension LunchHubApi.MealService.Endpoint {
  var path: String {
    switch self {
    case let .fetchMeals(shopId):
      return "/shops/\(shopId)/meals"
    }
  }
  var method: Method: {
    switch self {
    case .fetchMeals: return .get
    }
  }
  var task: Task {
    switch self {
    case .fetchMeals:
      return .requestPlain
    }
  }
}

extension LunchHubApi.MealService {
  public func fetchMeals(by shopId: String) -> Observable<[Meal]> {
    return self.provider.rx.request(.fetchMeals(shopId: shopId)) ...
  }
}
```